### PR TITLE
feat(cursor pagination): Implementing cursor pagination for lists

### DIFF
--- a/rapid/lib/constants.py
+++ b/rapid/lib/constants.py
@@ -34,6 +34,7 @@ class Constants(object):
     API_PREFIX = "/api/"
     FAILURES = 'failures'
     FAILURES_COUNT = 'failures_count'
+    CONTINUATION_HEADER = 'X-Rapid-Continuation-Token'
 
     @staticmethod
     def get_api_url(uri):

--- a/rapid/lib/http_wrapper.py
+++ b/rapid/lib/http_wrapper.py
@@ -1,6 +1,6 @@
 import flask
 
-from lib import Injectable
+from rapid.lib import Injectable
 
 
 class HTTPWrapper(Injectable):

--- a/rapid/lib/http_wrapper.py
+++ b/rapid/lib/http_wrapper.py
@@ -1,0 +1,9 @@
+import flask
+
+from lib import Injectable
+
+
+class HTTPWrapper(Injectable):
+
+    def current_request(self) -> flask.Request:
+        return flask.request

--- a/rapid/lib/utils.py
+++ b/rapid/lib/utils.py
@@ -51,6 +51,11 @@ def deep_merge(_a, _b, path=None):
 
 
 class RoutingUtil(object):
+    digit_to_letter = {
+        '0': 'X', '1': 'P', '2': 'A', '3': 'J', '4': 'l',
+        '5': 'R', '6': 'U', '7': 'W', '8': 'Q', '9': 'Z'
+    }
+    letter_to_digit = {v: k for k, v in digit_to_letter.items()}
 
     @staticmethod
     def is_valid_request(sent_api_key, api_key):
@@ -59,6 +64,14 @@ class RoutingUtil(object):
     @staticmethod
     def get_cihub_signature(secret_key, data):
         return hmac.new(secret_key.encode('ascii', 'ignore'), data, sha1).hexdigest()
+
+    @staticmethod
+    def obfuscate_id(model_id: int) -> str:
+        return ''.join(RoutingUtil.digit_to_letter[char] for char in str(model_id))
+
+    @staticmethod
+    def deobfuscate_id(obfuscated_id: str) -> int:
+        return int(''.join(RoutingUtil.letter_to_digit[char] for char in obfuscated_id))
 
 
 class ORMUtil(object):

--- a/tests/framework/unit_test.py
+++ b/tests/framework/unit_test.py
@@ -1,4 +1,7 @@
+from typing import Type, TypeVar
 from unittest import TestCase
+
+from mock.mock import MagicMock
 
 from rapid.lib import IOC
 from rapid.lib.framework.injectable import Injectable
@@ -12,3 +15,19 @@ class UnitTest(TestCase):
 
     def teardown_ioc(self):
         IOC.reset_ioc()
+
+    T = TypeVar('T')
+
+    def fill_object_with_mocks(self, clzz: Type[T], *args, **kwargs) -> T:
+        tmp_args = list(args)
+        if hasattr(clzz.__init__, '__code__'):
+            tmp_args.extend([MagicMock() for i in range(0, len(clzz.__init__.__code__.co_varnames) - 1 - len(args))])
+        tmp_kwargs = dict(kwargs)
+        if tmp_kwargs:
+            for key, value in tmp_kwargs.items():
+                index = -1
+                for var_name in clzz.__init__.__code__.co_varnames:
+                    if var_name == key:
+                        tmp_args[index] = value
+                    index += 1
+        return clzz(*tmp_args)

--- a/tests/workflow/test_api_controller.py
+++ b/tests/workflow/test_api_controller.py
@@ -1,8 +1,8 @@
 from mock.mock import MagicMock, patch
 
-from lib.constants import Constants
+from rapid.lib.constants import Constants
 from tests.framework.unit_test import UnitTest
-from workflow.api_controller import APIRouter
+from rapid.workflow.api_controller import APIRouter
 
 
 class TestAPIController(UnitTest):

--- a/tests/workflow/test_api_controller.py
+++ b/tests/workflow/test_api_controller.py
@@ -1,0 +1,48 @@
+from mock.mock import MagicMock, patch
+
+from lib.constants import Constants
+from tests.framework.unit_test import UnitTest
+from workflow.api_controller import APIRouter
+
+
+class TestAPIController(UnitTest):
+
+    def setUp(self):
+        self.controller = self.fill_object_with_mocks(APIRouter)
+
+    @patch.object(APIRouter, APIRouter._de_obfuscate_id.__name__)
+    def test_get_cursor_logic_get_from_header(self, mock_util):
+        mock_request = MagicMock()
+        mock_util.return_value = '123456'
+
+        self.controller.http_wrapper.current_request.return_value = mock_request
+        mock_header = MagicMock()
+        mock_header.get.return_value = '123456'
+        mock_request.headers = mock_header
+
+        self.assertEqual('123456', self.controller._get_cursor())
+        mock_util.assert_called_once_with('123456')
+        mock_header.get.assert_called_with(Constants.CONTINUATION_HEADER, None)
+
+    @patch.object(APIRouter, APIRouter._de_obfuscate_id.__name__)
+    def test_get_cursor_logic_get_from_json_post(self, mock_util):
+        mock_request = MagicMock()
+        mock_util.return_value = '123456'
+        mock_request.get_json.return_value = {'continuation_token': '123456'}
+
+        self.controller.http_wrapper.current_request.return_value = mock_request
+        mock_header = MagicMock()
+        mock_header.get.return_value = None
+        mock_request.headers = mock_header
+
+        self.assertEqual('123456', self.controller._get_cursor())
+        mock_util.assert_called_once_with('123456')
+
+    @patch.object(APIRouter, APIRouter._de_obfuscate_id.__name__)
+    @patch.object(APIRouter, APIRouter._get_args.__name__)
+    def test_get_cursor_logic_get_from_args(self, mock_args, mock_util):
+        mock_request = MagicMock()
+        mock_util.return_value = '123456'
+        mock_args.return_value = {'continuation_token': '123456'}
+
+        self.assertEqual('123456', self.controller._get_cursor())


### PR DESCRIPTION
## Purpose
We wanted to implement a quick cursor pagination across the lists APIs. This will enable Pagination.

- Adds a Header for X-Rapid-Continuation-Token
- Adds the ability to add 'continuation_token' to a JSON post or Args
- If the limit is equal to the amount returned, a token is provided
- If the limit is greater than the results returned, no token is provided
- Tokens are obfuscated

Either implementation works. 

### Details
To query for a list, i.e. pipelines: `/api/pipelines` in the response, you may get a 'X-Rapid-Continuation-Token'. Take that and send it in as a 'continuation_token' or 'X-Rapid-Continuation-Token' header, until you receive no further token.
