### PR TITLE
fix(action-config): copy ActionConfig when creating ActionInstance - GRAPH-3293

### DIFF
--- a/rapid/workflow/data/dal/pipeline_dal.py
+++ b/rapid/workflow/data/dal/pipeline_dal.py
@@ -26,6 +26,7 @@ except ImportError:
 from flask import Flask, request
 from flask.wrappers import Response
 from sqlalchemy.ext.declarative import DeclarativeMeta
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import asc
 
 from rapid.lib.queue_handler_constants import QueueHandlerConstants
@@ -195,6 +196,7 @@ class PipelineDal(GeneralDal, Injectable):
 
     def get_actions_query(self, session, pipeline_id):
         return session.query(Stage, Workflow, Action) \
+            .options(joinedload(Action.configuration)) \
             .filter(Stage.pipeline_id == pipeline_id) \
             .filter(Stage.id == Workflow.stage_id) \
             .filter(Workflow.id == Action.workflow_id) \

--- a/rapid/workflow/data/models.py
+++ b/rapid/workflow/data/models.py
@@ -49,13 +49,19 @@ class Action(BaseModel, Base):
         action_instance.status_id = StatusConstants.NEW
         action_instance.action_id = self.id
 
-        return ObjectConverter.copy_attributes(self, action_instance, ['cmd',
-                                                                       'executable',
-                                                                       'args',
-                                                                       'order',
-                                                                       'manual',
-                                                                       'callback_required',
-                                                                       'grain'])
+        ObjectConverter.copy_attributes(self, action_instance, ['cmd',
+                                                                'executable',
+                                                                'args',
+                                                                'order',
+                                                                'manual',
+                                                                'callback_required',
+                                                                'grain'])
+
+        if self.configuration is not None:
+            _configuration = ActionInstanceConfig()
+            _configuration.configuration = self.configuration.configuration
+            action_instance.configuration = _configuration
+        return action_instance
 
 
 class ActionConfig(BaseModel, Base):
@@ -80,7 +86,13 @@ class ActionInstance(DateModel, BaseModel, Base):
     workflow_instance_id = Column(Integer, ForeignKey('workflow_instances.id'), nullable=False, index=True)
     pipeline_instance_id = Column(Integer, ForeignKey("pipeline_instances.id"), nullable=False, index=True)
 
-    configuration = relationship('ActionInstanceConfig', lazy='select', uselist=False, backref="parent")
+    configuration = relationship(
+        'ActionInstanceConfig',
+        lazy='select',
+        uselist=False,
+        cascade='save-update, merge, delete, delete-orphan',
+        backref='parent',
+    )
     status = relationship('Status')
     pipeline_instance = relationship('PipelineInstance')
     action = relationship('Action')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,7 +15,7 @@
 """
 from ddt import ddt, data
 
-from rapid.workflow.data.models import Pipeline, Stage, Workflow, PipelineInstance, StageInstance, WorkflowInstance, Action, ActionInstance
+from rapid.workflow.data.models import Pipeline, Stage, Workflow, PipelineInstance, StageInstance, WorkflowInstance, Action, ActionInstance, ActionConfig, ActionInstanceConfig
 from tests.framework.unit_test import UnitTest
 
 
@@ -54,3 +54,20 @@ class TestModels(UnitTest):
         if 'check_fields' in model_map:
             for key, value in model_map['check_fields'].items():
                 self.assertEqual(value, getattr(instance_conversion, key))
+
+    def test_action_convert_to_instance_copies_configuration(self):
+        action = Action(name='Testing', id=1, cmd='bogus', executable='something', args='')
+        action.configuration = ActionConfig(configuration='{"foo": "bar"}')
+
+        action_instance = action.convert_to_instance()
+
+        self.assertIsNotNone(action_instance.configuration)
+        self.assertIsInstance(action_instance.configuration, ActionInstanceConfig)
+        self.assertEqual('{"foo": "bar"}', action_instance.configuration.configuration)
+
+    def test_action_convert_to_instance_without_configuration(self):
+        action = Action(name='Testing', id=1, cmd='bogus', executable='something', args='')
+
+        action_instance = action.convert_to_instance()
+
+        self.assertIsNone(action_instance.configuration)


### PR DESCRIPTION
## Summary

`Action.convert_to_instance` previously dropped the `Action`'s configuration on the floor when materializing an `ActionInstance`. Any `ActionConfig` attached to the action definition never made it onto the running instance, so downstream consumers that read `ActionInstance.configuration` always saw `None`.

## Changes

- **`Action.convert_to_instance`** now copies the related `ActionConfig` into a new `ActionInstanceConfig` when one exists. Putting the logic on the model means both call sites — `PipelineDal._setup_pipeline` (initial pipeline creation) and `InstanceWorkflowEngine._reconciled_stages` (mid-pipeline stage spawn) — pick it up automatically.
- **Explicit cascade on `ActionInstance.configuration`**: `save-update, merge, delete, delete-orphan`. The first two match the SQLAlchemy default but make intent visible — assigning the config to the relationship and `session.add`-ing the parent will propagate without each call site needing to know about the inner object. `delete, delete-orphan` cleans up the config row if the parent is removed or the config is detached.
- **Eager-load `Action.configuration` in `PipelineDal.get_actions_query`** to avoid an N+1 during initial pipeline setup. The mid-pipeline path is still lazy (bounded to one stage's actions per spawn) and worth a follow-up if it shows up in profiling.
- **Unit tests** covering both the config-present and config-absent paths of `Action.convert_to_instance`.

## Why this matters

Without this fix, any feature that depends on per-action configuration is silently broken at runtime — the column exists on `action_instances` and the relationship is defined, but `convert_to_instance` never populates it.

## Test plan

- [x] `pytest tests/test_models.py` — 9 passed (includes 2 new tests)
- [x] `pytest tests/master/util/test_instance_workflow_engine.py tests/master/data/database/dal/` — 74 passed (no regressions in the workflow engine or DAL test suites)
- [ ] Manually verify on a pipeline with an action that has an `ActionConfig` — confirm the `ActionInstanceConfig` row is created on both initial pipeline kickoff and on next-stage spawn after a stage completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)