### PR TITLE
Output all responses as JSON

### DIFF
--- a/rapid/ci/vcs/github_controller.py
+++ b/rapid/ci/vcs/github_controller.py
@@ -19,11 +19,10 @@ from functools import wraps
 
 from flask import Flask
 from flask.globals import request
-from flask.wrappers import Response
 
 from rapid.master.master_configuration import MasterConfiguration
 from rapid.ci.data.github_dal import GithubHelper
-from rapid.lib import json_response, HttpException
+from rapid.lib import json_response, HttpException, json_error_response
 from rapid.lib.framework.injectable import Injectable
 from rapid.lib.modules import WorkflowModule
 
@@ -47,7 +46,7 @@ class GithubController(Injectable):
             if 'X-Hub-Signature' in request.headers \
                     and GithubHelper.is_valid_request(request.headers['X-Hub-Signature'], self.rapid_config.github_webhooks_key, request.data):
                 return func(*args, **kwargs)
-            return Response("Not authorized", status=401)
+            return json_error_response("Not authorized", 401)
         return decorated_view
 
     def __process_request(self):

--- a/rapid/client/__init__.py
+++ b/rapid/client/__init__.py
@@ -18,14 +18,9 @@ import os
 import threading
 import time
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
 from flask import Flask
 
-from rapid.lib import setup_ioc, is_primary_worker, setup_logging, setup_status_route, setup_config_from_file
+from rapid.lib import setup_ioc, is_primary_worker, setup_logging, setup_status_route, setup_config_from_file, register_json_error_handlers
 from .parsers import load_parsers
 from .communicator.client_communicator import ClientCommunicator
 from .controllers import register_controllers
@@ -33,14 +28,6 @@ from .controllers import register_controllers
 app = Flask("rapidci_client")
 app.rapid_config = {'_is': 'client'}
 logger = logging.getLogger("rapid")
-
-
-@app.errorhandler(500)
-def internal_error(exception):
-    response = json.dumps(exception.to_dict())
-    response.status_code = exception.status_code
-    response.content_type = 'application/json'
-    return response
 
 
 def setup_logger(flask_app):
@@ -61,6 +48,7 @@ def configure_application(flask_app, args):
     setup_logger(flask_app)
     load_parsers()
     register_controllers(flask_app)
+    register_json_error_handlers(flask_app)
     if is_primary_worker() and not args.run and not args.upgrade:
         setup_client_register_thread()
         clean_workspace()

--- a/rapid/client/controllers/main.py
+++ b/rapid/client/controllers/main.py
@@ -22,7 +22,10 @@ try:
 except ImportError:
     import json
 
+from flask import Response
+
 from rapid.lib import api_key_required
+from rapid.lib.exceptions import HttpException
 from ...lib.base_controller import BaseController
 
 
@@ -43,6 +46,6 @@ class Main(BaseController):
                                          'X-RapidCI-Time': str(time.time() * 1000)},
                                 verify=self.flask_app.rapid_config.ignore_cert_verify)
         if request.status_code == 200:
-            return "Success!"
+            return Response(json.dumps({"message": "Success!"}), content_type='application/json')
 
-        raise BaseException("There was a problem registrating.")
+        raise HttpException("There was a problem registering.", 500)

--- a/rapid/lib/__init__.py
+++ b/rapid/lib/__init__.py
@@ -97,13 +97,35 @@ def setup_ioc(flask_app):
     IOC.register_global(Flask, flask_app)
 
 
+def json_error_response(message, status=500):
+    return Response(json.dumps({"message": message}), status=status, content_type='application/json')
+
+
+def register_json_error_handlers(flask_app):
+    """Ensure every unhandled error leaves the app as JSON rather than Flask's default HTML page."""
+    from werkzeug.exceptions import HTTPException
+
+    def handle_http_exception(error):
+        # rapid HttpException subclasses already render a JSON body via get_body(); pass them through.
+        if isinstance(error, HttpException):
+            return error
+        return json_error_response(error.description, error.code or 500)
+
+    def handle_uncaught_exception(error):
+        logging.getLogger('rapid').exception(error)
+        return json_error_response("An internal error occurred.", 500)
+
+    flask_app.register_error_handler(HTTPException, handle_http_exception)
+    flask_app.register_error_handler(Exception, handle_uncaught_exception)
+
+
 def api_key_required(func):
     @wraps(func)
     def decorated_view(*args, **kwargs):
         if 'X-Rapidci-Api-Key' in get_current_request().headers \
                 and RoutingUtil.is_valid_request(get_current_request().headers['X-Rapidci-Api-Key'], get_current_app().rapid_config.api_key):
             return func(*args, **kwargs)
-        return Response("Not authorized", status=401)
+        return json_error_response("Not authorized", 401)
     return decorated_view
 
 
@@ -126,7 +148,7 @@ def basic_auth(func):
                 return func(*args, **kwargs)
         except (KeyError, TypeError):
             pass
-        return Response("Invalid Authorization", status=401)
+        return json_error_response("Invalid Authorization", 401)
     return wrapper
 
 
@@ -143,13 +165,13 @@ def json_response(exception_class=None, message=None):
                     return response
                 return Response(json.dumps(response), content_type="application/json")
             except Exception as exception_stuff:  # pylint: disable=broad-except
-                if hasattr(exception_stuff, 'get_body'):
-                    return exception_stuff
-                exception = exception_class(message) if exception_class is not None else Exception(str(exception_stuff))
-                response = Response(json.dumps(exception.to_dict())) if hasattr(exception, 'to_dict') else Response(json.dumps({"message": exception.__dict__}))
-                response.status_code = exception.status_code if hasattr(exception, 'status_code') else 500
-                response.content_type = 'application/json'
-                return response
+                if isinstance(exception_stuff, HttpException):
+                    return exception_stuff  # already renders a JSON body via get_body()
+                if exception_class is not None:
+                    return json_error_response(message, 500)
+                description = getattr(exception_stuff, 'description', None) or str(exception_stuff)
+                status = getattr(exception_stuff, 'code', None) or getattr(exception_stuff, 'status_code', None) or 500
+                return json_error_response(description, status)
         return wrapped_json_response
     return wrap
 
@@ -172,4 +194,4 @@ def setup_logging(flask_app):
 def setup_status_route(flask_app):
     @flask_app.route('/status')
     def status():  # pylint: disable=unused-variable
-        return 'Running'
+        return Response(json.dumps({"status": "Running"}), content_type='application/json')

--- a/rapid/master/__init__.py
+++ b/rapid/master/__init__.py
@@ -18,10 +18,10 @@ import logging
 import threading
 import time
 
-from flask import Flask, Response
+from flask import Flask
 
 from rapid.master.data import run_db_downgrade, configure_db
-from rapid.lib import setup_ioc, setup_config_from_file, is_primary_worker, setup_status_route
+from rapid.lib import setup_ioc, setup_config_from_file, is_primary_worker, setup_status_route, register_json_error_handlers
 from rapid.lib.framework.ioc import IOC
 from .controllers import register_controllers
 from .data import configure_data_layer, run_db_upgrades, create_revision
@@ -36,21 +36,6 @@ logger = logging.getLogger("rapid")
 logger.addHandler(handler)  # pylint: disable=no-member
 logger.setLevel(logging.INFO)  # pylint: disable=no-member
 
-@app.errorhandler(500)
-def internal_error(exception):
-    response = Response(status=500, content_type='application/json')
-    response.data = _to_dict(exception)
-    if hasattr(exception, 'message'):
-        app.logger.error(exception.message)  # pylint: disable=no-member
-    else:
-        app.logger.error(exception)
-    return response
-
-
-def _to_dict(exception):
-    _rv = {'message': exception.message if hasattr(exception, 'message') else 'An exception has occurred'}
-    return _rv
-
 
 def configure_application(flask_app, args, manual_db_upgrade=False):
     setup_ioc(flask_app)
@@ -61,6 +46,7 @@ def configure_application(flask_app, args, manual_db_upgrade=False):
     configure_data_layer(flask_app)
     register_controllers(flask_app)
     setup_status_route(flask_app)
+    register_json_error_handlers(flask_app)
 
     if args.static_file_dir:
         flask_app.rapid_config.static_file_directory = args.static_file_dir

--- a/rapid/master/controllers/api/upgrade_controller.py
+++ b/rapid/master/controllers/api/upgrade_controller.py
@@ -14,6 +14,11 @@
  limitations under the License.
 """
 
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
 from flask import Response
 
 from rapid.lib.version import Version
@@ -31,4 +36,5 @@ class UpgradeController(object):
 
     def upgrade_master(self, version):
         worked = UpgradeUtil.upgrade_version(version, self.flask_app.rapid_config)
-        return Response("It worked!" if worked else "It didn't work, version {} restored!".format(Version.get_version()), status=200 if worked else 505)
+        message = "It worked!" if worked else "It didn't work, version {} restored!".format(Version.get_version())
+        return Response(json.dumps({"message": message}), status=200 if worked else 505, content_type='application/json')

--- a/rapid/qa/controllers/qa_controller.py
+++ b/rapid/qa/controllers/qa_controller.py
@@ -16,10 +16,10 @@ limitations under the License.
 import logging
 
 from flask.globals import request
-from werkzeug.exceptions import HTTPException
 
 from rapid.qa.qa_service import QaService
 from rapid.lib import api_key_required, json_response
+from rapid.lib.exceptions import HttpException
 from rapid.lib.framework.injectable import Injectable
 
 logger = logging.getLogger("rapid")
@@ -50,7 +50,7 @@ class QAController(Injectable):
             except Exception as exception:  # pylint: disable=broad-except
                 logger.exception(exception)
                 
-        raise HTTPException("Missing Pipeline Instance Id")
+        raise HttpException("Missing Pipeline Instance Id", 400)
 
     @json_response()
     def get_qa_testmap_coverage(self, pipeline_instance_id):

--- a/rapid/workflow/api_controller.py
+++ b/rapid/workflow/api_controller.py
@@ -136,7 +136,7 @@ class APIRouter(Injectable):
                 allowed_fields, query = self._get_additional_fields(clazz, query)
                 instance = query.one()
                 return Response(json.dumps(instance.serialize(allowed_children=allowed_fields)), content_type='application/json')
-        return Response("Not Valid", status=404)
+        return Response(json.dumps({"message": "Not Valid"}), status=404, content_type='application/json')
 
     def _get_cursor(self) -> int:
         cursor = None
@@ -192,7 +192,7 @@ class APIRouter(Injectable):
                     results.append(result.serialize(fields))
                 return Response(json.dumps(results), content_type='application/json', headers=self._get_pagination_header(results, query_limit))
         else:
-            return Response(status=404)
+            return Response(json.dumps({"message": "Not Found"}), status=404, content_type='application/json')
 
     @json_response()
     def cancel_pipeline_instance(self, pipeline_instance_id):
@@ -331,7 +331,7 @@ class APIRouter(Injectable):
         if self._is_valid(endpoint):
             clazz = self.class_map[endpoint]
             return Response(json.dumps(self._create_from_request(clazz, self.http_wrapper.current_request().get_json())), content_type="application/json")
-        return Response(status=404)
+        return Response(json.dumps({"message": "Not Found"}), status=404, content_type='application/json')
 
     def edit_object(self, endpoint, _id):
         if self._is_valid(endpoint):
@@ -340,7 +340,7 @@ class APIRouter(Injectable):
                 dal = self._retrieve_dal(clazz)
                 instance = dal.edit_object(session, clazz, _id, self.http_wrapper.current_request().json)
                 return Response(json.dumps(instance.serialize()), content_type='application/json')
-        return Response(status=404)
+        return Response(json.dumps({"message": "Not Found"}), status=404, content_type='application/json')
 
     def delete_object(self, endpoint, _id):
         if self._is_valid(endpoint):
@@ -349,7 +349,7 @@ class APIRouter(Injectable):
                 dal = self._retrieve_dal(clazz)
                 instance = dal.delete_object(session, clazz, _id)
                 return Response(json.dumps(instance.serialize()), content_type='application/json')
-        return Response(status=404)
+        return Response(json.dumps({"message": "Not Found"}), status=404, content_type='application/json')
 
     def reset_action_instance(self, _id):
         try:
@@ -370,7 +370,7 @@ class APIRouter(Injectable):
             return Response(json.dumps(self.action_instance_service.finish_action_instance(_id, self.http_wrapper.current_request().get_json())), content_type='application/json')
         except Exception as exception:
             logger.error(exception)
-            return Response("Something went wrong!", status=500)
+            return Response(json.dumps({"message": "Something went wrong!"}), status=500, content_type='application/json')
 
     def metadata(self, endpoint=None):
         if self._is_valid(endpoint):

--- a/rapid/workflow/data/dal/pipeline_dal.py
+++ b/rapid/workflow/data/dal/pipeline_dal.py
@@ -87,7 +87,9 @@ class PipelineDal(GeneralDal, Injectable):
 
     def start_pipeline_instance(self, pipeline_id):
         data = request.get_json()
-        return "It worked!" if self.create_pipeline_instance(pipeline_id, data) else "It Failed!"
+        worked = self.create_pipeline_instance(pipeline_id, data)
+        message = "It worked!" if worked else "It Failed!"
+        return Response(out_json.dumps({"message": message}), status=200 if worked else 500, content_type='application/json')
 
     def get_pipeline_by_id(self, pipeline_id, session=None):
         if session is None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad cross-cutting HTTP behavior change may break clients that expected plaintext or HTML errors; error payload shape and status handling in `json_response` also changed.
> 
> **Overview**
> Standardizes API responses so clients consistently receive **`application/json`** instead of plain text or Flask’s default HTML error pages.
> 
> Adds **`json_error_response`** and **`register_json_error_handlers`** in `rapid.lib`, wired into **master** and **client** app startup (replacing ad-hoc `@app.errorhandler(500)` blocks). Global handlers return JSON for Werkzeug **`HTTPException`**s and uncaught exceptions; **`api_key_required`**, **`basic_auth`**, and GitHub webhook auth now use the shared JSON 401 helper.
> 
> Updates **`json_response`** to route errors through **`HttpException`** / **`json_error_response`** instead of building ad-hoc error bodies. Controllers and DAL endpoints that returned bare strings or empty 404 bodies now return JSON objects (typically `{"message": ...}`); **`/status`** returns `{"status": "Running"}`. QA missing-header errors switch from werkzeug **`HTTPException`** to **`HttpException`** with status 400.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9adc5db48a18828be1670acc864413b377281984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->